### PR TITLE
Remove the need to display the requester in the new requests form.

### DIFF
--- a/src/html/newrequest.html
+++ b/src/html/newrequest.html
@@ -156,13 +156,6 @@ $(document).ready(function() {
 	  <fieldset>
 	    <legend>Basic Information</legend>
 	    
-	    <label for="requester_dn">Requester:</label>
-	    <div class="input-group">
-	      <!--	<span class="input-group-addon">Hello World</span>-->
-	      <input class="form-control" type="text" value="###requester_dn###" readonly>
-	    </div>
-
-	    <br>
 	    <label for="sim_lead">Sim Lead:</label>
 	    <div class="input-group">
 	      <input class="form-control" placeholder="Sim Lead" type="text" name="sim_lead" required>

--- a/src/python/CertWebServer.py
+++ b/src/python/CertWebServer.py
@@ -32,9 +32,9 @@ class CertWebServer(object):
         """Return the new requests page."""
 
         try:
-            _, clientDN, _ = check_credentials(self.dburl)
+            check_credentials(self.dburl)
         except AuthenticationError as e:
             return e.message
 
         with open(os.path.join(self.html_root, 'newrequest.html')) as new_request:
-            return new_request.read().replace('###requester_dn###', clientDN)
+            return new_request.read()

--- a/src/python/services/RequestsDB.py
+++ b/src/python/services/RequestsDB.py
@@ -62,7 +62,12 @@ class RequestsDB(object):
     def POST(self, **kwargs):
         """REST Post method."""
         print "IN POST", kwargs
-        requester_id, _, _ = check_credentials(self.dburl)
+        try:
+            # if coming through the web app then this should be
+            # checked already but could use curl
+            requester_id, _, _ = check_credentials(self.dburl)
+        except AuthenticationError as e:
+            return e.message
         kwargs['request_date'] = datetime.now().strftime('%d/%m/%Y')
         kwargs['timestamp'] = str(datetime.now())
         kwargs['status'] = 'Requested'


### PR DESCRIPTION
Each user will get their own view of the web app so there is no need to
show the user their own DN when submitting requests.

Commits:
        77a104f444c71b797f5dbb546df51dd25933d5f3
