### PR TITLE
Explicitly disable pylint naming convention on REST methods.

### DIFF
--- a/src/python/services/CVMFSAppVersions.py
+++ b/src/python/services/CVMFSAppVersions.py
@@ -22,7 +22,7 @@ class CVMFSAppVersions(object):
         self.cvmfs_root = cvmfs_root
         self.valid_apps = valid_apps
 
-    def GET(self, appid=None):
+    def GET(self, appid=None):  # pylint: disable=C0103
         """REST GET method."""
         print "IN AppVersion GET: appid=(%s)" % appid
         if appid not in self.valid_apps:

--- a/src/python/services/GitTagMacros.py
+++ b/src/python/services/GitTagMacros.py
@@ -26,7 +26,7 @@ class GitTagMacros(object):
         self.tag_cache = pylru.lrucache(50)
 
 #    @pylru.lrudecorator(50)  # don't want to cache list of tags where tagid = None
-    def GET(self, tagid=None):
+    def GET(self, tagid=None):  # pylint: disable=C0103
         """REST Get method."""
         print "IN GET: tagid=(%s)" % tagid
         if tagid in self.tag_cache:

--- a/src/python/services/RequestsDB.py
+++ b/src/python/services/RequestsDB.py
@@ -28,6 +28,7 @@ class Requests(SQLTableBase):
     selected_macros = Column(String(250), nullable=False)
     ForeignKeyConstraint(['requester_id'], ['users.id'])
 
+
 class RequestsDB(object):
     """
     RequestsDB Service.
@@ -43,7 +44,7 @@ class RequestsDB(object):
         self.dburl = dburl
         create_db(dburl)
 
-    def GET(self, reqid=None):
+    def GET(self, reqid=None):  # pylint: disable=C0103
         """REST Get method."""
         print "IN GET: reqid=(%s)" % reqid
         with db_session(self.dburl) as session:
@@ -71,7 +72,6 @@ class RequestsDB(object):
                 columns += ['request_date', 'sim_lead', 'status', 'description']
                 return json.dumps({'data': [dict(zip(columns, request)) for request in query.all()]})
 
-
             table = html.HTML().table(border='1')
             request = session.query(Requests).filter(Requests.id == reqid).first()
             if request is not None:
@@ -81,7 +81,7 @@ class RequestsDB(object):
                     tr.td(str(value))
         return str(table)
 
-    def POST(self, **kwargs):
+    def POST(self, **kwargs):  # pylint: disable=C0103
         """REST Post method."""
         print "IN POST", kwargs
         try:
@@ -98,13 +98,13 @@ class RequestsDB(object):
             session.add(Requests(requester_id=requester.id, **kwargs))
         return self.GET()
 
-    def PUT(self, reqid, **kwargs):
+    def PUT(self, reqid, **kwargs):  # pylint: disable=C0103
         """REST Put method."""
         print "IN PUT: reqid=(%s)" % reqid, kwargs
         with db_session(self.dburl) as session:
             session.query(Requests).filter(Requests.id == reqid).update(kwargs)
 
-    def DELETE(self, reqid):
+    def DELETE(self, reqid):  # pylint: disable=C0103
         """REST Delete method."""
         print "IN DELETE: reqid=(%s)" % reqid
         with db_session(self.dburl) as session:


### PR DESCRIPTION
The cherrypy REST methods must be called GET, POST, PUT and DELETE which is incompatible with pylint's default method naming convention so we explicitly disable it for these lines.

```
modified:   services/CVMFSAppVersions.py
modified:   services/GitTagMacros.py
modified:   services/RequestsDB.py
```
