### PR TITLE
Disable pylint naming convention as it incorrectly things class is co…

### DIFF
--- a/src/python/sqlalchemy_utils.py
+++ b/src/python/sqlalchemy_utils.py
@@ -27,7 +27,7 @@ class _IterableBase(object):
                                   lambda value: isinstance(value, InstrumentedAttribute)):
             yield name, getattr(self, name)
 
-SQLTableBase = declarative_base(cls=_IterableBase)
+SQLTableBase = declarative_base(cls=_IterableBase)  # pylint: disable=C0103
 
 
 def create_db(url):


### PR DESCRIPTION
…nst.

	modified:   sqlalchemy_utils.py