### PR TITLE
Ensure selected_macros is a list.

### DIFF
--- a/src/python/services/RequestsDB.py
+++ b/src/python/services/RequestsDB.py
@@ -61,6 +61,8 @@ class RequestsDB(object):
         kwargs['request_date'] = datetime.now().strftime('%d/%m/%Y')
         kwargs['timestamp'] = str(datetime.now())
         kwargs['status'] = 'Requested'
+        if not isinstance(kwargs['selected_macros'], list):
+            kwargs['selected_macros'] = [kwargs['selected_macros']]
         kwargs['selected_macros'] = '\n'.join(kwargs['selected_macros'])
         kwargs['output_lfns'] = ''
         with db_session(self.dburl) as session:


### PR DESCRIPTION
This fixes when only one macro is selected it is given as a string and splitting it results in one letter per job which breaks.

	modified:   src/python/services/RequestsDB.py