### PR TITLE
Always update the services DB timestamp.

### DIFF
--- a/scripts/ganga-daemon.py
+++ b/scripts/ganga-daemon.py
@@ -63,15 +63,17 @@ def check_services(session, cert, verify):
     status = 'down'
     if requests.get("https://dirac.gridpp.ac.uk/DIRAC/", cert=cert, verify=verify).status_code == 200:
         status = 'up'
-    query_dirac.update({'status': status})
     if query_dirac.one_or_none() is None:
-        session.add(Services(name='DIRAC', status=status))
+        session.add(Services(name='DIRAC', status=status, timestamp=datetime.now()))
+    else:
+        query_dirac.update({'status': status, 'timestamp': datetime.now()})
 
     # gangad
     query_gangad = query.filter(Services.name == "gangad")
-    query_gangad.update({'status': 'up'})
     if query_gangad.one_or_none() is None:
-        session.add(Services(name='gangad', status='up'))
+        session.add(Services(name='gangad', status='up', timestamp=datetime.now()))
+    else:
+        query_gangad.update({'status': 'up', 'timestamp': datetime.now()})
 
 def monitor_requests(session):
     monitored_requests = session.query(Requests)\


### PR DESCRIPTION
Had the problem that if the status of a service didn't change a lot then the update would not actually do anything and therefore the timestamp would always be old. This caused the web front end to report services as stuck. Also in this PR i change the logic to reduce by one the number of calls to the DB.

	modified:   scripts/ganga-daemon.py