### PR TITLE
Enable the Ganga monitoring loop.

### DIFF
--- a/scripts/ganga-daemon.py
+++ b/scripts/ganga-daemon.py
@@ -48,8 +48,8 @@ def exit_status(dburl):
                         'timestamp': datetime.utcnow()})
 
 def daemon_main(dburl, delay, cert, verify=False):
+    ganga.enableMonitoring()
     while True:
-        ganga.runMonitoring()
         with sqlalchemy_utils.db_session(dburl) as session:
             check_services(session, cert, verify)
             monitor_requests(session)


### PR DESCRIPTION
Running the monitoring in a one shot fashion while we loop seemed buggy and unstable so now we just enable Ganga's monitoring loop.

	modified:   scripts/ganga-daemon.py