### PR TITLE
Reload the table after admin change.

### DIFF
--- a/src/html/admins.html
+++ b/src/html/admins.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-<!-- Add jQuery library using Google CDN (Content Delivery Network)-->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.3/jquery.min.js"></script>
-
-<!-- Latest compiled and minified Bootstrap Javascript -->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
-
 <!-- TiTaToggle CSS -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/titatoggle/1.2.11/titatoggle-dist-min.css">
 

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -122,7 +122,8 @@
     $("#Admins").fancybox({
       type: "ajax",
       href: "/admins",
-      title: "Admin Management"
+      title: "Admin Management",
+      afterClose: function(){location.reload();}
     });
 
     // Table row selection


### PR DESCRIPTION
After the admin management fancybox closes we need to refresh the table.
This is because if a user demotes himself then he needs to nolonger have
the admin view. This requires a full reload rather than an ajax reload since
the table structure as well as context menus will be different as well as
it's contents.

	modified:   src/html/admins.html
	modified:   src/html/index.html