### PR TITLE
Fix for individual row info.

### DIFF
--- a/src/python/services/RequestsDB.py
+++ b/src/python/services/RequestsDB.py
@@ -61,7 +61,7 @@ class RequestsDB(object):
             table = html.HTML().table(border='1')
             request = session.query(Requests).filter(Requests.id == reqid).first()
             if request is not None:
-                for colname, value in request:
+                for colname, value in request.iteritems():
                     row = table.tr()
                     row.td(colname)
                     row.td(str(value))


### PR DESCRIPTION
When moving the Request table object to extending the Mapping abstract base class we now need to iterate key/value pairs with iteritems.