### PR TITLE
Switch macro live search style to contains.

### DIFF
--- a/src/html/newrequest.html
+++ b/src/html/newrequest.html
@@ -291,7 +291,7 @@ $(document).ready(function() {
 	      <div class="col-xs-8">
 		<div class="input-group macro-selection">
 		  <!-- having no name attribute means it's not submitted as part of the form -->
-		  <select id="macros" class="selectpicker form-control" data-size="6" width="100%" data-selected-text-format="count > 1" data-live-search="true" data-live-search-style="startsWith" data-dropup-auto="false" data-live-search-placeholder="Search..." title="Macros" multiple disabled></select>
+		  <select id="macros" class="selectpicker form-control" data-size="6" width="100%" data-selected-text-format="count > 1" data-live-search="true" data-dropup-auto="false" data-live-search-placeholder="Search..." title="Macros" multiple disabled></select>
 		</div>
 	      </div>
 


### PR DESCRIPTION
macro selection was using live search style 'startsWith' which made it harder to locate certain macros.

	modified:   src/html/newrequest.html

This closes https://github.com/alexanderrichards/LZProduction/issues/92