### PR TITLE
Enforce bulk submission in block of 1000.

### DIFF
--- a/src/python/dirac_utils.py
+++ b/src/python/dirac_utils.py
@@ -14,6 +14,7 @@ status_map = {'Done': 'Completed',
               'Checking': 'Submitted',
               'Running': 'Running',
               'Received': 'Requested',
+              'Unknown': 'Unknown',
               'Killed': 'Killed',
               'Deleted': 'Deleted'}
 
@@ -32,7 +33,7 @@ class DiracClient(xmlrpclib.ServerProxy):
     def _status_accumulate(self, status_dict):
         ret = {}
         status = "Unknown"
-        status_acc = status_accumulator(('Deleted', 'Killed', 'Done', 'Failed', 'Received',
+        status_acc = status_accumulator(('Unknown', 'Deleted', 'Killed', 'Done', 'Failed', 'Received',
                                          'Checking', 'Queued', 'Waiting', 'Running'))
         for k, v in status_dict.iteritems():
             ret[int(k)] = v

--- a/src/python/tables/Requests.py
+++ b/src/python/tables/Requests.py
@@ -22,7 +22,7 @@ class Requests(SQLTableBase):
 
 
     def submit(self, session):
-        status_acc = status_accumulator(('Deleted', 'Killed', 'Completed', 'Failed', 'Requested', 'Approved', 'Submitted', 'Running'))
+        status_acc = status_accumulator(('Unknown', 'Deleted', 'Killed', 'Completed', 'Failed', 'Requested', 'Approved', 'Submitted', 'Running'))
         # with sqlalchemy_utils.db_session(self.dburl) as session:
         jobs = session.query(ParametricJobs).filter(ParametricJobs.request_id == self.id).all()
         for job in jobs:
@@ -31,7 +31,7 @@ class Requests(SQLTableBase):
 
 
     def update_status(self, session):
-        status_acc = status_accumulator(('Deleted', 'Killed', 'Completed', 'Failed', 'Requested', 'Approved', 'Submitted', 'Running'))
+        status_acc = status_accumulator(('Unknown', 'Deleted', 'Killed', 'Completed', 'Failed', 'Requested', 'Approved', 'Submitted', 'Running'))
         # with sqlalchemy_utils.db_session(self.dburl) as session:
         jobs = session.query(ParametricJobs).filter(ParametricJobs.request_id == self.id).all()
         for job in jobs:


### PR DESCRIPTION
Issues arose when Elena submitted parametric jobs with order 10K subjobs. We suspect that the issues were a timeout of the Dirac socket due to having to create so many jobs. This patch forces all jobs to be submitted in batches of no more than 1000 at a time.