### PR TITLE
Fix CVMFS failure bug.

### DIFF
--- a/src/python/frontend/CVMFSAppVersions.py
+++ b/src/python/frontend/CVMFSAppVersions.py
@@ -1,10 +1,12 @@
 """CVMFS Servcice."""
 import os
 import re
+import logging
 import cherrypy
 import html
 from natsort import natsorted
 
+logger = logging.getLogger(__name__)
 VERSION_RE = re.compile(r"^release-(\d{1,3}\.\d{1,3}\.\d{1,3})$")
 
 
@@ -30,7 +32,13 @@ class CVMFSAppVersions(object):
             print "Invalid app type %s" % appid
             return ''
         html_ = html.HTML()
-        _, dirs, _ = os.walk(os.path.join(self.cvmfs_root, appid)).next()
+        dirs = []
+        try:
+            _, dirs, _ = os.walk(os.path.join(self.cvmfs_root, appid)).next()
+        except StopIteration:
+            logger.error("Couldn't access CVMFS dir: %s",
+                         os.path.join(self.cvmfs_root, appid))
+
         for dir_ in natsorted(dirs, reverse=True):
             for version in VERSION_RE.findall(dir_):
                 html_.option(version)


### PR DESCRIPTION
When CVMFS fails the iterator next calls raises StopIteration even with a single call to next. This must be caught and delt with. This also includes logging the error.

	modified:   src/python/frontend/CVMFSAppVersions.py