### PR TITLE
Fix bug in autorescheduling.

### DIFF
--- a/src/python/tables/ParametricJobs.py
+++ b/src/python/tables/ParametricJobs.py
@@ -136,4 +136,5 @@ class ParametricJobs(SQLTableBase):
             if this is not None:
                 this.status = self.status
                 this.counters = self.counters
+                this.reschedule = self.reschedule
         return self.status


### PR DESCRIPTION
The reschedule flag was not getting reset for manual rescheduling and if the job was autorescheduled for say being in dirac state stalled, there was no list to iterate over for failed jobs causing an error for iterating over None.

	modified:   src/python/backend/DiracRPCServer.py
	modified:   src/python/tables/ParametricJobs.py