### PR TITLE
Fix security bug in RequestDBAPI PUT.

### DIFF
--- a/src/python/frontend/RequestsDBAPI.py
+++ b/src/python/frontend/RequestsDBAPI.py
@@ -124,7 +124,7 @@ class RequestsDBAPI(object):
             query = session.query(Requests).filter_by(id=reqid)
             if not requester.admin:
                 query = query.filter_by(requester_id=requester.id)
-            query.update(kwargs)
+            query.update(subdict(kwargs, ('description', 'sim_lead', 'detector', 'source')))
         return self.GET()
 
     def DELETE(self, reqid):  # pylint: disable=invalid-name


### PR DESCRIPTION
This bug meant that a user could change any DB column they liked, including the status to anything. This did not allow them to affect jobs other than their own but it did mean that they could screw up the system by changing fields that were never intended for the user to modify.

	modified:   src/python/frontend/RequestsDBAPI.py