### PR TITLE
Remove badges link decoration.

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -63,7 +63,7 @@
     <h1>LZ Production Requests</h1>
     <div align="right">
       <img border="0" alt="Ganga daemon status" src="https://img.shields.io/badge/gangad-{{gangad_status}}-{{gangad_status_colour}}.svg">
-      <a href="https://dirac.gridpp.ac.uk/DIRAC/GridPP/lz_user/jobs/JobMonitor/display" style="text-decoration:none">
+      <a href="https://dirac.gridpp.ac.uk:8443/DIRAC/?view=tabs&theme=Grey&url_state=1|*DIRAC.JobMonitor.classes.JobMonitor:," style="text-decoration:none">
 	<img border="0" alt="DIRAC status" src="https://img.shields.io/badge/DIRAC-{{DIRAC_status}}-{{DIRAC_status_colour}}.svg">
       </a>
       {% if user.admin %}

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -63,7 +63,7 @@
     <h1>LZ Production Requests</h1>
     <div align="right">
       <img border="0" alt="Ganga daemon status" src="https://img.shields.io/badge/gangad-{{gangad_status}}-{{gangad_status_colour}}.svg">
-      <a href="https://dirac.gridpp.ac.uk/DIRAC/GridPP/lz_user/jobs/JobMonitor/display">
+      <a href="https://dirac.gridpp.ac.uk/DIRAC/GridPP/lz_user/jobs/JobMonitor/display" style="text-decoration:none">
 	<img border="0" alt="DIRAC status" src="https://img.shields.io/badge/DIRAC-{{DIRAC_status}}-{{DIRAC_status_colour}}.svg">
       </a>
       {% if user.admin %}


### PR DESCRIPTION
This patch hides the visible link underline decoration from around the dirac badge on the web app main page.

	modified:   src/html/index.html